### PR TITLE
Export DumpList is not working if a value contains a comma

### DIFF
--- a/Mailchimp/Methods/MCExport.php
+++ b/Mailchimp/Methods/MCExport.php
@@ -34,15 +34,12 @@ class MCExport extends RestClient {
             return $data;
         $result = preg_split('/$\R?^/m', $data);
 
-        $header = str_replace(array('[', ']', '"'), "", $result[0]);
-        $headerArray = explode(",", $header);
+        $headerArray = json_decode($result[0]);
         unset($result[0]);
 
         $data = array();
         foreach ($result as $value) {
-            $clean = str_replace(array('[', ']', '"'), "", $value);
-            $cleanArray = explode(",", $clean);
-            $data[] = array_combine($headerArray, $cleanArray);
+            $data[] = array_combine($headerArray, json_decode($value));
         }
 
         return $data;


### PR DESCRIPTION
The str_replace/explode hack produces a too large and invalid value array if one of the values contains a comma.
