### PR TITLE
YAML Deprecation Symfony 3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     hype_mailchimp:
-      class: %hype_mailchimp.class%
-      arguments: [%hypemailchimp.config%]
+      class: '%hype_mailchimp.class%'
+      arguments: ['%hypemailchimp.config%']
       


### PR DESCRIPTION
Unquoting YAML % is deprectaed, [see here](http://symfony.com/blog/new-in-symfony-3-1-yaml-deprecations).
