### PR TITLE
Do not use Buzz > 0.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.0|~3.0",
-        "kriswallsmith/buzz":">=0.7",
+        "kriswallsmith/buzz":">=0.7 <0.17",
         "ext-curl": "*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Simple change to disallow composer dependency kriswallsmith/buzz v0.17 and up.

Buzz 0.17 introduces radical API break.