### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,8 +10,8 @@ class Configuration implements ConfigurationInterface {
 
 
     public function getConfigTreeBuilder() {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('hype_mailchimp');
+        $treeBuilder = new TreeBuilder('hype_mailchimp');
+        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('hype_mailchimp');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
Fix a depreciation :

A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

According to https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes